### PR TITLE
DNS FW/IDS - GUI UX Updates

### DIFF
--- a/admin/templates/base.j2
+++ b/admin/templates/base.j2
@@ -58,6 +58,46 @@
 {% if active == "tuning" or active == "dns" %}
 <script src="{{ haurl }}static/js/bootstrap-table-editable.js"></script>
 <script src="{{ haurl }}static/js/bootstrap-editable.min.js"></script>
+<script>
+    /* Modified by Gemini using model gemini-2.0-flash on 2026-05-25 */
+    function alertFormatter(value, row, index) {
+        return `<div class="form-check form-switch">
+                    <input class="form-check-input alert-toggle" type="checkbox" role="switch" ${value == 1 ? 'checked' : ''}>
+                </div>`;
+    }
+
+    function actionFormatter(value, row, index, field) {
+        return `<div class="form-check form-switch">
+                    <input class="form-check-input action-toggle" type="checkbox" role="switch" ${value === 'block' ? 'checked' : ''}>
+                </div>`;
+    }
+
+    window.operateEvents = {
+        'change .alert-toggle': function (e, value, row, index) {
+            const $el = $(e.target);
+            const newValue = $el.prop('checked') ? "1" : "0";
+            const url = $el.closest('table').attr('data-editable-url');
+            $.post(url, { pk: row.id, name: 'alert', value: newValue })
+                .fail(function() {
+                    $el.prop('checked', !$el.prop('checked'));
+                    alert('Update failed');
+                });
+        },
+        'change .action-toggle': function (e, value, row, index) {
+            const $el = $(e.target);
+            const isChecked = $el.prop('checked');
+            const $table = $el.closest('table');
+            const offValue = $table.attr('data-off-value') || 'pass';
+            const newValue = isChecked ? 'block' : offValue;
+            const url = $table.attr('data-editable-url');
+            $.post(url, { pk: row.id, name: 'action', value: newValue })
+                .fail(function() {
+                    $el.prop('checked', !isChecked);
+                    alert('Update failed');
+                });
+        }
+    };
+</script>
 {% endif %}
 </body>
 </html>

--- a/admin/templates/dns.j2
+++ b/admin/templates/dns.j2
@@ -23,7 +23,8 @@
         data-editable-url="{{ haurl }}admin/data/dns/domains"
         data-id-field="id"
         data-sort-name="counter"
-        data-sort-order="desc">
+        data-sort-order="desc"
+        data-off-value="pass">
         <thead>
             <tr>
             <th data-field="id" data-visible="false">ID</th>
@@ -31,8 +32,8 @@
             <th data-field="scope" data-sortable="true">Scope</th>
             <th data-field="domain" data-sortable="true">Domain</th>
             <th data-field="counter" data-sortable="true">Hit Count</th>
-            <th data-field="action" data-editable="true" data-sortable="true">Action</th>
-            <th data-field="alert" data-editable="true" data-sortable="true">Alert</th>
+            <th data-field="action" data-formatter="actionFormatter" data-events="operateEvents" data-sortable="true">Block</th>
+            <th data-field="alert" data-formatter="alertFormatter" data-events="operateEvents" data-sortable="true">Alert</th>
             </tr>
         </thead>
     </table>
@@ -50,7 +51,8 @@
         data-editable-url="{{ haurl }}admin/data/dns/queries"
         data-id-field="id"
         data-sort-name="counter"
-        data-sort-order="desc">
+        data-sort-order="desc"
+        data-off-value="pass">
         <thead>
             <tr>
             <th data-field="id" data-visible="false">ID</th>
@@ -61,8 +63,8 @@
             <th data-field="src" data-sortable="true">Source IP</th>
             <th data-field="scope" data-sortable="true">Scope</th>
             <th data-field="counter" data-sortable="true">Hit Count</th>
-            <th data-field="action" data-editable="true" data-sortable="true">Action</th>
-            <th data-field="alert" data-editable="true" data-sortable="true">Alert</th>
+            <th data-field="action" data-formatter="actionFormatter" data-events="operateEvents" data-sortable="true">Block</th>
+            <th data-field="alert" data-formatter="alertFormatter" data-events="operateEvents" data-sortable="true">Alert</th>
             </tr>
         </thead>
     </table>

--- a/admin/templates/tuning.j2
+++ b/admin/templates/tuning.j2
@@ -10,7 +10,10 @@
     <button class="nav-link" id="host-tab" data-bs-toggle="tab" data-bs-target="#host-tab-pane" type="button" role="tab" aria-controls="host-tab-pane" aria-selected="false">Hosts</button>
   </li>
   <li class="nav-item" role="presentation">
-    <button class="nav-link" id="dnsignored-tab" data-bs-toggle="tab" data-bs-target="#dnsignored-tab-pane" type="button" role="tab" aria-controls="dnsignored-tab-pane" aria-selected="false">DNS Ignored</button>
+    <button class="nav-link" id="dnsignored-tab" data-bs-toggle="tab" data-bs-target="#dnsignored-tab-pane" type="button" role="tab" aria-controls="dnsignored-tab-pane" aria-selected="false">Ignored DNS Blocks</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="dnspass-tab" data-bs-toggle="tab" data-bs-target="#dnspass-tab-pane" type="button" role="tab" aria-controls="dnspass-tab-pane" aria-selected="false">Alerting DNS Pass</button>
   </li>
 </ul>
 <div class="tab-content" id="myTabContent">
@@ -75,6 +78,31 @@
         data-searchable="true"
         data-url="{{ haurl }}admin/data/tuning/dnsignored"
         data-editable-url="{{ haurl }}admin/data/tuning/dnsignored"
+        data-id-field="id"
+        data-sort-name="name"
+        data-sort-order="asc">
+        <thead>
+            <tr>
+            <th data-field="id" data-visible="false">ID</th>
+            <th data-field="type" data-sortable="true">Type</th>
+            <th data-field="name" data-sortable="true">Name</th>
+            <th data-field="counter" data-sortable="true">Hit Count</th>
+            <th data-field="alert" data-formatter="alertFormatter" data-events="operateEvents" data-sortable="true">Alert</th>
+            </tr>
+        </thead>
+    </table>
+  </div>
+  <div class="tab-pane fade" id="dnspass-tab-pane" role="tabpanel" aria-labelledby="dnspass-tab" tabindex="0">
+  <p>&nbsp</p>
+    <table
+        id="table-tuning-dnspass"
+        data-toggle="table"
+        data-pagination="true"
+        data-side-pagination="server"
+        data-search="true"
+        data-searchable="true"
+        data-url="{{ haurl }}admin/data/tuning/dnspass"
+        data-editable-url="{{ haurl }}admin/data/tuning/dnspass"
         data-id-field="id"
         data-sort-name="name"
         data-sort-order="asc">

--- a/admin/templates/tuning.j2
+++ b/admin/templates/tuning.j2
@@ -27,14 +27,15 @@
         data-editable-url="{{ haurl }}admin/data/tuning/networks"
         data-id-field="id"
         data-sort-name="name"
-        data-sort-order="asc">
+        data-sort-order="asc"
+        data-off-value="learn">
         <thead>
             <tr>
             <th data-field="id" data-visible="false">ID</th>
             <th data-field="name" data-editable="true" data-sortable="true">Name</th>
             <th data-field="ip" data-sortable="true">IP Address</th>
             <th data-field="type" data-sortable="true">Type</th>
-            <th data-field="action" data-editable="true" data-sortable="true">Action</th>
+            <th data-field="action" data-formatter="actionFormatter" data-events="operateEvents" data-sortable="true">Block</th>
             <th data-field="created" data-sortable="true">Created</th>
             </tr>
         </thead>
@@ -83,7 +84,7 @@
             <th data-field="type" data-sortable="true">Type</th>
             <th data-field="name" data-sortable="true">Name</th>
             <th data-field="counter" data-sortable="true">Hit Count</th>
-            <th data-field="alert" data-editable="true" data-sortable="true">Alert</th>
+            <th data-field="alert" data-formatter="alertFormatter" data-events="operateEvents" data-sortable="true">Alert</th>
             </tr>
         </thead>
     </table>

--- a/admin/web.py
+++ b/admin/web.py
@@ -1067,6 +1067,8 @@ def bootstrap():
                     if 'alert' not in columns:
                         logger.info('Adding alert column to %s table', table[0])
                         connection.execute(f'ALTER TABLE "{table[0]}" ADD COLUMN "alert" INTEGER DEFAULT 1')
+                        logger.info('Updating existing records to alert=0 where action=pass for %s', table[0])
+                        connection.execute(f'UPDATE "{table[0]}" SET "alert" = 0 WHERE "action" = \'pass\'')
                     else:
                         logger.debug('DB Schema %s- Nothing to do', table[0])
                     cursor.close()

--- a/admin/web.py
+++ b/admin/web.py
@@ -106,15 +106,19 @@ DB_SCHEMA_V_DOMAINS = f'CREATE VIEW "{DB_V_DOMAINS}" AS SELECT "{DB_T_DOMAINS}".
 DB_V_QUERIES = "v_queries"
 DB_SCHEMA_V_QUERIES = f'CREATE VIEW "{DB_V_QUERIES}" AS SELECT "{DB_T_QUERIES}".id, "{DB_T_QUERIES}".last_seen, "{DB_T_QUERIES}".query, "{DB_T_DOMAINS}".domain, "{DB_T_QUERIES}".query_type, "{DB_T_QUERIES}".src, "{DB_T_NETWORKS}".ip as scope, "{DB_T_QUERIES}".counter, "{DB_T_QUERIES}".action, "{DB_T_QUERIES}".alert FROM "{DB_T_QUERIES}"  LEFT JOIN "{DB_T_NETWORKS}" ON "{DB_T_QUERIES}".scope_id = "{DB_T_NETWORKS}".id LEFT JOIN "{DB_T_DOMAINS}" ON "{DB_T_QUERIES}".domain_id = "{DB_T_DOMAINS}".id'
 
-DB_V_DNS_IGNORED = "v_dns_ignored"
-DB_SCHEMA_V_DNS_IGNORED = f'CREATE VIEW "{DB_V_DNS_IGNORED}" AS SELECT \'domain\' AS type, counter, domain AS name, alert, id FROM "{DB_T_DOMAINS}" WHERE alert = 0 UNION ALL SELECT \'query\' AS type, counter, query AS name, alert, id FROM "{DB_T_QUERIES}" WHERE alert = 0'
+DB_V_DNS_IGNORED_BLOCKED = "v_dns_ignored_blocked"
+DB_SCHEMA_V_DNS_IGNORED_BLOCKED = f'CREATE VIEW "{DB_V_DNS_IGNORED_BLOCKED}" AS SELECT \'domain\' AS type, counter, domain AS name, alert, id FROM "{DB_T_DOMAINS}" WHERE action = \'block\' AND alert = 0 UNION ALL SELECT \'query\' AS type, counter, query AS name, alert, id FROM "{DB_T_QUERIES}" WHERE action = \'block\' AND alert = 0'
+
+DB_V_DNS_ALERTING_PASS = "v_dns_alerting_pass"
+DB_SCHEMA_V_DNS_ALERTING_PASS = f'CREATE VIEW "{DB_V_DNS_ALERTING_PASS}" AS SELECT \'domain\' AS type, counter, domain AS name, alert, id FROM "{DB_T_DOMAINS}" WHERE action = \'pass\' AND alert = 1 UNION ALL SELECT \'query\' AS type, counter, query AS name, alert, id FROM "{DB_T_QUERIES}" WHERE action = \'pass\' AND alert = 1'
 
 DB_ID_SALT = 'This is not for security, it is for uniqueness'
 DB_SCHEMA = [
     (DB_T_ALERTS, DB_SCHEMA_T_ALERTS),
     (DB_V_DOMAINS, DB_SCHEMA_V_DOMAINS),
     (DB_V_QUERIES, DB_SCHEMA_V_QUERIES),
-    (DB_V_DNS_IGNORED, DB_SCHEMA_V_DNS_IGNORED)
+    (DB_V_DNS_IGNORED_BLOCKED, DB_SCHEMA_V_DNS_IGNORED_BLOCKED),
+    (DB_V_DNS_ALERTING_PASS, DB_SCHEMA_V_DNS_ALERTING_PASS)
 ]
 
 # Stuff for the webserver.
@@ -654,14 +658,14 @@ class DataTuningNetworkPage(Resource):
 
 class DataTuningDNSIgnoredPage(Resource):
     """
-        /admin/data/tuning/dnsignored <- JSON Data management for ignored DNS records
+        /admin/data/tuning/dnsignored <- JSON Data management for ignored DNS blocks
     """
     def getChild(self, path, request): # pylint: disable=W0613
         return DataTuningDNSIgnoredPage()
 
     def render_POST(self, request):
         status = b"Update Failed"
-        logger.debug("DNS IGNORED POST String -> %s", request.args)
+        logger.debug("DNS IGNORED BLOCKED POST String -> %s", request.args)
 
         try:
             update_name = request.args[b'name'][0].decode('utf-8')
@@ -693,7 +697,7 @@ class DataTuningDNSIgnoredPage(Resource):
         # Attempt to update both tables, the ID is unique so only one will match (or none)
         sql_action(f'UPDATE "{DB_T_DOMAINS}" SET "{update_name}" = ? WHERE "id" = ?', (update_value, record_id))
         sql_action(f'UPDATE "{DB_T_QUERIES}" SET "{update_name}" = ? WHERE "id" = ?', (update_value, record_id))
-        
+
         return b'Ok'
 
     def render_GET(self, request):
@@ -710,8 +714,8 @@ class DataTuningDNSIgnoredPage(Resource):
                 search_string = f"%{search_string}%"
                 sql_where = " WHERE (name LIKE ?) "
                 sql_params = (search_string, search_string, limit, offset)
-        
-        data = sql_action(f"WITH CTE as (SELECT count(*) total FROM {DB_V_DNS_IGNORED}{sql_where}) SELECT type,counter,name,alert,id,(SELECT total FROM CTE) total FROM {DB_V_DNS_IGNORED}{sql_where} ORDER BY {sort} {order} LIMIT ? OFFSET ?", sql_params)
+
+        data = sql_action(f"WITH CTE as (SELECT count(*) total FROM {DB_V_DNS_IGNORED_BLOCKED}{sql_where}) SELECT type,counter,name,alert,id,(SELECT total FROM CTE) total FROM {DB_V_DNS_IGNORED_BLOCKED}{sql_where} ORDER BY {sort} {order} LIMIT ? OFFSET ?", sql_params)
         rows = []
         total = 0
         if data:
@@ -734,6 +738,88 @@ class DataTuningDNSIgnoredPage(Resource):
         request.setHeader('Content-Type', 'application/json')
         return json.dumps(response).encode('utf-8')
 
+class DataTuningDNSAlertingPassPage(Resource):
+    """
+        /admin/data/tuning/dnspass <- JSON Data management for alerting DNS passes
+    """
+    def getChild(self, path, request): # pylint: disable=W0613
+        return DataTuningDNSAlertingPassPage()
+
+    def render_POST(self, request):
+        status = b"Update Failed"
+        logger.debug("DNS ALERTING PASS POST String -> %s", request.args)
+
+        try:
+            update_name = request.args[b'name'][0].decode('utf-8')
+        except Exception:
+            logger.error("Exception: %s - %s", str(sys.exc_info()[0]), str(sys.exc_info()[1]))
+            logger.error(traceback.format_exc())
+            return (status)
+
+        try:
+            update_value = request.args[b'value'][0].decode('utf-8')
+        except Exception:
+            logger.error("Exception: %s - %s", str(sys.exc_info()[0]), str(sys.exc_info()[1]))
+            logger.error(traceback.format_exc())
+            return (status)
+
+        if update_name not in ['alert']:
+            return (status)
+
+        if update_value not in ['0', '1']:
+            return (status)
+
+        try:
+            record_id = request.args[b'pk'][0].decode('utf-8')
+        except Exception:
+            logger.error("Exception: %s - %s", str(sys.exc_info()[0]), str(sys.exc_info()[1]))
+            logger.error(traceback.format_exc())
+            return (status)
+
+        # Attempt to update both tables, the ID is unique so only one will match (or none)
+        sql_action(f'UPDATE "{DB_T_DOMAINS}" SET "{update_name}" = ? WHERE "id" = ?', (update_value, record_id))
+        sql_action(f'UPDATE "{DB_T_QUERIES}" SET "{update_name}" = ? WHERE "id" = ?', (update_value, record_id))
+
+        return b'Ok'
+
+    def render_GET(self, request):
+        limit, offset = get_limit_offset(request)
+        sort, order = get_sort_n_order(request, "name", ['type', 'counter', 'name', 'alert'])
+        sql_where = ""
+        sql_params = (limit, offset)
+        try:
+            search_string = request.args[b'search'][0].decode('utf-8')
+        except Exception:
+            pass
+        else:
+            if search_string != "":
+                search_string = f"%{search_string}%"
+                sql_where = " WHERE (name LIKE ?) "
+                sql_params = (search_string, search_string, limit, offset)
+
+        data = sql_action(f"WITH CTE as (SELECT count(*) total FROM {DB_V_DNS_ALERTING_PASS}{sql_where}) SELECT type,counter,name,alert,id,(SELECT total FROM CTE) total FROM {DB_V_DNS_ALERTING_PASS}{sql_where} ORDER BY {sort} {order} LIMIT ? OFFSET ?", sql_params)
+        rows = []
+        total = 0
+        if data:
+            for row in data:
+                rows.append(
+                    {
+                        'type': row[0],
+                        'counter': row[1],
+                        'name': row[2],
+                        'alert': row[3],
+                        'id': row[4]
+                    }
+                )
+                total = row[5]
+        response = {
+            "data":"tuning-dns-alerting-pass",
+            "total": total,
+            "rows": rows
+        }
+        request.setHeader('Content-Type', 'application/json')
+        return json.dumps(response).encode('utf-8')
+
 class DataTuningRoot(Resource):
     """
         Route processor for /admin/data/tuning/
@@ -747,6 +833,8 @@ class DataTuningRoot(Resource):
             return DataTuningHostPage()
         if path_str == "dnsignored":
             return DataTuningDNSIgnoredPage()
+        if path_str == "dnspass":
+            return DataTuningDNSAlertingPassPage()
         return DataTuningRoot()
 
     def render_GET(self, request):

--- a/dns/listener.py
+++ b/dns/listener.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Modified by Gemini using model gemini-1.5-pro-002 on 2026-05-25
 # pylint: disable=W0718
 import sys
 import json
@@ -856,10 +857,13 @@ class DNSInterceptor(BaseResolver):
                 self.linkSQLs(str(src_ip), scope_id, str(qname), str(qtype), the_domain_id)
 
             self.log.info("✨ %s -> %s [Type: %s] => %s", src_ip, qname, qtype, the_domain)
-            if not self.passThePacket(the_domain_action):
-                self.log.warning("🔥 New Authority DOMAIN %s Detected for Request %s 🔥", the_domain, qname)
+            if not self.passThePacket(the_domain_action) or (not learning_mode and the_domain_alert):
+                if not self.passThePacket(the_domain_action):
+                    self.log.warning("🔥 New Authority DOMAIN %s Detected for Request %s 🔥", the_domain, qname)
+
                 if the_domain_id is None:
                     the_domain_action, the_domain_id, the_domain_alert = self.sqlDomains(the_domain,scope_id,'block')
+
                 if WEBHOOKER and the_domain_alert:
                     data = {
                         'type':'dns',
@@ -873,13 +877,16 @@ class DNSInterceptor(BaseResolver):
                     }
                     post_process_domain = Process(target=postwebhook, args=(data, self.log)) # Start a new process to avoid DNS latency
                     post_process_domain.start()
-                if DNS_FIREWALL_ON:
+
+                if DNS_FIREWALL_ON and not self.passThePacket(the_domain_action):
                     self.log.info("🔥🔥 DOMAIN BLOCKED %s 🔥🔥", the_domain)
                     reply.header.rcode = getattr(RCODE,'NXDOMAIN')
                     return reply
 
-            if DNS_DETECT_ON_HOST and not self.passThePacket(the_query_action):
-                self.log.warning("🔥 New QUERY %s Detected for %s (%s) 🔥", qname, src_ip, scope_id)
+            if DNS_DETECT_ON_HOST and (not self.passThePacket(the_query_action) or (not learning_mode and the_query_alert)):
+                if not self.passThePacket(the_query_action):
+                    self.log.warning("🔥 New QUERY %s Detected for %s (%s) 🔥", qname, src_ip, scope_id)
+
                 if WEBHOOKER and the_query_alert:
                     data = {
                         'type':'dns',
@@ -893,7 +900,8 @@ class DNSInterceptor(BaseResolver):
                     }
                     post_process_query = Process(target=postwebhook, args=(data, self.log))
                     post_process_query.start()
-                if DNS_FIREWALL_ON:
+
+                if DNS_FIREWALL_ON and not self.passThePacket(the_query_action):
                     self.log.info("🔥🔥 QUERY BLOCKED %s 🔥🔥", the_domain)
                     reply.header.rcode = getattr(RCODE,'NXDOMAIN')
                     return reply

--- a/dns/listener.py
+++ b/dns/listener.py
@@ -978,6 +978,8 @@ def bootstrap(log:logging=logging):
                     if 'alert' not in columns:
                         log.info('Adding alert column to %s table', table[0])
                         connection.execute(f'ALTER TABLE "{table[0]}" ADD COLUMN "alert" INTEGER DEFAULT 1')
+                        log.info('Updating existing records to alert=0 where action=pass for %s', table[0])
+                        connection.execute(f'UPDATE "{table[0]}" SET "alert" = 0 WHERE "action" = \'pass\'')
                     else:
                         log.debug('DB Schema %s - Nothing to do', table[0])
                     cursor.close()

--- a/tests/admin/test_web.py
+++ b/tests/admin/test_web.py
@@ -143,7 +143,8 @@ def setup_data_db(tmp_path, monkeypatch):
     )
     web.sql_action(web.DB_SCHEMA_V_DOMAINS, ())
     web.sql_action(web.DB_SCHEMA_V_QUERIES, ())
-    web.sql_action(web.DB_SCHEMA_V_DNS_IGNORED, ())
+    web.sql_action(web.DB_SCHEMA_V_DNS_IGNORED_BLOCKED, ())
+    web.sql_action(web.DB_SCHEMA_V_DNS_ALERTING_PASS, ())
 
 
 # ============================================================================
@@ -426,19 +427,19 @@ def test_data_tuning_dns_ignored_page_get_and_post(tmp_path, monkeypatch):
     """
     Test the DNS ignored tuning data API endpoint (GET and POST).
     
-    GET test: Verifies ignored domains and queries are listed
+    GET test: Verifies ignored DNS blocks are listed
     POST test: Verifies alert status can be toggled (e.g., 0 -> 1)
     """
     setup_data_db(tmp_path, monkeypatch)
-    # Add an ignored domain
+    # Add an ignored domain (must be action=block and alert=0)
     web.sql_action(
         f'INSERT INTO "{web.DB_T_DOMAINS}" ("id", "domain", "counter", "scope", "action", "last_seen", "alert") VALUES (?, ?, ?, ?, ?, ?, ?)',
-        ("d_ignored", "ignored.com", 5, "n1", "pass", "2026-02-09T00:00:00+00:00", 0),
+        ("d_ignored", "ignored.com", 5, "n1", "block", "2026-02-09T00:00:00+00:00", 0),
     )
-    # Add an ignored query
+    # Add an ignored query (must be action=block and alert=0)
     web.sql_action(
         f'INSERT INTO "{web.DB_T_QUERIES}" ("id", "src", "scope_id", "query", "query_type", "counter", "action", "last_seen", "domain_id", "alert") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-        ("q_ignored", "1.2.3.4", "n1", "secret.com", "A", 10, "pass", "2026-02-09T00:00:00+00:00", "d1", 0),
+        ("q_ignored", "1.2.3.4", "n1", "secret.com", "A", 10, "block", "2026-02-09T00:00:00+00:00", "d1", 0),
     )
 
     # Test GET
@@ -463,6 +464,46 @@ def test_data_tuning_dns_ignored_page_get_and_post(tmp_path, monkeypatch):
     assert rows[0][0] == 1
 
 
+def test_data_tuning_dns_alerting_pass_page_get_and_post(tmp_path, monkeypatch):
+    """
+    Test the DNS alerting pass tuning data API endpoint (GET and POST).
+    
+    GET test: Verifies alerting DNS passes are listed
+    POST test: Verifies alert status can be toggled (e.g., 1 -> 0)
+    """
+    setup_data_db(tmp_path, monkeypatch)
+    # Add an alerting pass domain (must be action=pass and alert=1)
+    web.sql_action(
+        f'INSERT INTO "{web.DB_T_DOMAINS}" ("id", "domain", "counter", "scope", "action", "last_seen", "alert") VALUES (?, ?, ?, ?, ?, ?, ?)',
+        ("d_alert_pass", "alerting.com", 3, "n1", "pass", "2026-02-09T00:00:00+00:00", 1),
+    )
+    # Add an alerting pass query (must be action=pass and alert=1)
+    web.sql_action(
+        f'INSERT INTO "{web.DB_T_QUERIES}" ("id", "src", "scope_id", "query", "query_type", "counter", "action", "last_seen", "domain_id", "alert") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        ("q_alert_pass", "1.2.3.4", "n1", "notify.me", "A", 8, "pass", "2026-02-09T00:00:00+00:00", "d_alert_pass", 1),
+    )
+
+    # Test GET
+    output = web.DataTuningDNSAlertingPassPage().render_GET(DummyRequest(args={b"limit": [b"10"], b"offset": [b"0"]}))
+    data = json.loads(output.decode("utf-8"))
+    assert data["total"] == 2
+    names = [row["name"] for row in data["rows"]]
+    assert "alerting.com" in names
+    assert "notify.me" in names
+
+    # Test POST (disable alert for domain)
+    post_request = DummyRequest(args={b"name": [b"alert"], b"value": [b"0"], b"pk": [b"d_alert_pass"]})
+    assert web.DataTuningDNSAlertingPassPage().render_POST(post_request) == b"Ok"
+    rows = web.sql_action(f'SELECT "alert" FROM "{web.DB_T_DOMAINS}" WHERE id = ?', ("d_alert_pass",))
+    assert rows[0][0] == 0
+
+    # Test POST (disable alert for query)
+    post_request = DummyRequest(args={b"name": [b"alert"], b"value": [b"0"], b"pk": [b"q_alert_pass"]})
+    assert web.DataTuningDNSAlertingPassPage().render_POST(post_request) == b"Ok"
+    rows = web.sql_action(f'SELECT "alert" FROM "{web.DB_T_QUERIES}" WHERE id = ?', ("q_alert_pass",))
+    assert rows[0][0] == 0
+
+
 def test_data_roots():
     """
     Test that the data API root resources route to the correct child pages.
@@ -483,6 +524,7 @@ def test_data_roots():
     assert isinstance(tuning_root.getChild(b"networks", DummyRequest()), web.DataTuningNetworkPage)
     assert isinstance(tuning_root.getChild(b"hosts", DummyRequest()), web.DataTuningHostPage)
     assert isinstance(tuning_root.getChild(b"dnsignored", DummyRequest()), web.DataTuningDNSIgnoredPage)
+    assert isinstance(tuning_root.getChild(b"dnspass", DummyRequest()), web.DataTuningDNSAlertingPassPage)
     assert tuning_root.render_GET(DummyRequest()) == b'{"data":"tuning"}'
 
     data_root = web.DataRoot()


### PR DESCRIPTION
GUI Toggles
- BLOCK/PASS is now a toggle (Block On/Off)
- 0/1 (for Alerts) is now a toggle
- BLOCK/LEARN is now a toggle (Block On/Off)

DNS Listener now honours separate block / alert actions -- DNS Firewall switch must be enabled in config for blocking.

Updated Tuning page, so surface edge cases
1. Block but No Alert
2. Pass but Alert

The Default for new records is block & alert -- After learning mode.
All Current Pass's are migrated to Pass without alert -- to maintain the existing silent functionality.